### PR TITLE
Narrow type when using "isArray" function

### DIFF
--- a/src/Array.d.ts
+++ b/src/Array.d.ts
@@ -75,7 +75,7 @@ declare namespace SiftArray {
 
   export function insert<T>(array: T[], index: number, ...values: T[]): T[]
 
-  export function is(value: any): boolean
+  export function is(value: any): value is Array<unknown>
 
   export function last<T>(array: T[]): T
 


### PR DESCRIPTION
# The problem

Currently when you use the "isArray" function you have to manually cast the variable type to the Array<unknown>.

# Proposed changes

We should allow the TypeScript type inferrer to narrow the type of the variable.